### PR TITLE
Updates to work with the latest kafka-python API changes

### DIFF
--- a/tail2kafka/tail2kafka
+++ b/tail2kafka/tail2kafka
@@ -8,13 +8,15 @@ from kafka.producer import SimpleProducer
 from optparse import OptionParser
 import subprocess
 import atexit
+import logging
+logging.basicConfig()
 
 
 should_stop = False
 
 def create_kafka_producer(options):
-    kafka = KafkaClient(options.host, int(options.port))
-    producer = SimpleProducer(kafka, options.topic, async=True, batch_send=True,
+    kafka = KafkaClient(options.host + ':' + str(int(options.port)))
+    producer = SimpleProducer(kafka, async=True, batch_send=True,
             batch_send_every_n=int(options.batch_size), batch_send_every_t=int(options.batch_time),
             req_acks=SimpleProducer.ACK_NOT_REQUIRED)
     return producer


### PR DESCRIPTION
tail2kafka would not work with the latest kafka-python library.  It seems that the API for both the KafkaClient and the SimpleProducer have changed.  The KafkaClient now wants the host/port as a single string like "localhost:9092".  The SimpleProducer no longer wants the topic.  I also imported the logging because it made it easier to use the logging in the kafka-python library when debugging and errors arise.  
